### PR TITLE
ADV-8 Configure ActiveRecord to use UUID

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,23 @@ orbs:
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
-  build:
+  security:
+    resource_class: large
+    docker:
+      - image: cimg/ruby:3.1.3-node
+    executor: ruby/default
+    steps:
+      - checkout
+      - ruby/install-deps
+      - run:
+          command: 'bundle exec brakeman -q -o tmp/brakeman.html'
+          name: 'Analyse code for security vulnerabilities'
+      - store_artifacts:
+          path: tmp/brakeman.html
+      - run:
+          command: 'bundle exec bundle audit check --update'
+          name: 'Analyse Ruby gems for security vulnerabilities'
+  linting:
     resource_class: large
     docker:
       - image: cimg/ruby:3.1.3-node
@@ -25,14 +41,6 @@ jobs:
       - node/install-packages:
           with-cache: true
           pkg-manager: yarn
-      - run:
-          command: 'bundle exec brakeman -q -o tmp/brakeman.html'
-          name: 'Analyse code for security vulnerabilities'
-      - store_artifacts:
-          path: tmp/brakeman.html
-      - run:
-          command: 'bundle exec bundle audit check --update'
-          name: 'Analyse Ruby gems for security vulnerabilities'
       - ruby/rubocop-check:
           format: progress
           parallel: true
@@ -40,16 +48,6 @@ jobs:
       - run:
           command: 'bin/erb_lint'
           name: 'Lint ERB'
-  linting:
-    resource_class: large
-    docker:
-      - image: cimg/ruby:3.1.3-node
-    steps:
-      - checkout
-      - ruby/install-deps
-      - ruby/rubocop-check:
-          format: progress
-          label: Inspecting wth Rubocop
   test:
     resource_class: large
     docker:
@@ -132,11 +130,11 @@ workflows:
   verify: # This is the name of the workflow, feel free to change it to better match your workflow.
     # Inside the workflow, you define the jobs you want to run.
     jobs:
-      - build
+      - security
       - linting
       - test:
           requires:
-            - build
+            - linting
       - coverage:
           context: SonarCloud
           requires:

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -36,3 +36,7 @@ PreCommit:
   RuboCop:
     enabled: true
     command: ["bundle", "exec", "rubocop", "-A", "--parallel"]
+
+CommitMsg:
+  CapitalizedSubject:
+    enabled: false

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,38 @@
+# Use this file to configure the Overcommit hooks you wish to use. This will
+# extend the default configuration defined in:
+# https://github.com/sds/overcommit/blob/master/config/default.yml
+#
+# At the topmost level of this YAML file is a key representing type of hook
+# being run (e.g. pre-commit, commit-msg, etc.). Within each type you can
+# customize each hook, such as whether to only run it on certain files (via
+# `include`), whether to only display output if it fails (via `quiet`), etc.
+#
+# For a complete list of hooks, see:
+# https://github.com/sds/overcommit/tree/master/lib/overcommit/hook
+#
+# For a complete list of options that you can use to customize hooks, see:
+# https://github.com/sds/overcommit#configuration
+#
+# Uncomment the following lines to make the configuration take effect.
+
+#PreCommit:
+#  RuboCop:
+#    enabled: true
+#    on_warn: fail # Treat all warnings as failures
+#
+#  TrailingWhitespace:
+#    enabled: true
+#    exclude:
+#      - '**/db/structure.sql' # Ignore trailing whitespace in generated files
+#
+#PostCheckout:
+#  ALL: # Special hook name that customizes all hooks of this type
+#    quiet: true # Change all post-checkout hooks to only display output on failure
+#
+#  IndexTags:
+#    enabled: true # Generate a tags file with `ctags` each time HEAD changes
+
+PreCommit:
+  RuboCop:
+    enabled: true
+    command: ["bundle", "exec", "rubocop", "-A", "--parallel"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is a learning project for myself to learn Rails 7, Ruby and best practices 
 
 * Podman or Docker
 * `dip` gem
+* `overcommit` gem
 
 ## Setup
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,4 +2,7 @@
 
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+
+  # Adjust default sort order for UUID primary key
+  self.implicit_order_column = :created_at
 end

--- a/config/initializers/generators.rb
+++ b/config/initializers/generators.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.config.generators do |g|
+  g.orm :active_record, primary_key_type: :uuid
+end

--- a/config/initializers/generators.rb
+++ b/config/initializers/generators.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Rails.application.config.generators do |g|
-  g.orm :active_record, primary_key_type: :uuid
+  g.orm(:active_record, primary_key_type: :uuid)
 end

--- a/db/migrate/20221230073545_enable_uuid.rb
+++ b/db/migrate/20221230073545_enable_uuid.rb
@@ -1,0 +1,5 @@
+class EnableUuid < ActiveRecord::Migration[7.0]
+  def change
+    enable_extension "pgcrypto"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 0) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_30_073545) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
 end


### PR DESCRIPTION
- Configure the ActiveRecord generator to use the `uuid` type instead of `integer` for primary keys.
- Adds configuration for `[Overcommit](https://github.com/sds/overcommit)` gem to run RuboCop linting at commit.
- Replaces `build` step in CircleCI config with `security` step.